### PR TITLE
Backwards compatible with existing apache2 charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -87,6 +87,10 @@ class Charm(CharmBase):
                 vhost_content = base64.b64encode(f.read()).decode('utf-8')
             vhost_rdata = '- {' f'port: "{self.VHOST_PORT}", template: {vhost_content}' '}'
             event.relation.data[self.app]['vhosts'] = vhost_rdata
+            event.relation.data[self.unit]['vhosts'] = vhost_rdata
+        else:
+            for k in event.relation.data[self.unit].keys():
+                del event.relation.data[self.unit][k]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When i related this charm with [apache2](https://jaas.ai/apache2/35) it wouldn't create the vhost until i made these adjustments. 